### PR TITLE
Enable robot.hear()

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -12,7 +12,8 @@ export default {
             GatewayIntentBits.Guilds,
             GatewayIntentBits.DirectMessages,
             GatewayIntentBits.GuildMessages,
-            GatewayIntentBits.GuildMessageReactions
+            GatewayIntentBits.GuildMessageReactions,
+            GatewayIntentBits.MessageContent
         ], partials: [Partials.Channel, Partials.Message, Partials.User, Partials.Reaction]})
         const adapter = new DiscordAdapter(robot, client)
         return adapter

--- a/src/DiscordAdapter.mjs
+++ b/src/DiscordAdapter.mjs
@@ -25,8 +25,13 @@ class DiscordAdapter extends Adapter {
             this.emit('connected')
         })
     }
+    // This is now probably misnamed, since we're not concerned with *only* messages directed at the bot
     #wasToBot(message, botId) {
-        return message.mentions && !message.mentions.users.find(u => u.id == botId)
+        // message.mentions is always an object in discord.js; check users collection size
+        const users = message.mentions && message.mentions.users
+        if (!users || users.size === 0) return false
+        // Return true when the message mentions users but does NOT mention the bot
+        return !users.has(botId)
     }
     messageWasUpdated(oldMessage, newMessage) {
         if(newMessage.author.bot) return


### PR DESCRIPTION
This...*works*, but it may not be the best way to go about it. I'm open any suggestions you may have :-)

In order for this to work the application needs to have `Message Content Intent` granted to it. It may also be worth noting this in the README, because it may not be exactly obvious to people who have used hubot on other chat platforms.

Fixes #11.